### PR TITLE
Build for different VTK variants

### DIFF
--- a/.azure-pipelines/azure-pipelines-linux.yml
+++ b/.azure-pipelines/azure-pipelines-linux.yml
@@ -8,14 +8,30 @@ jobs:
     vmImage: ubuntu-latest
   strategy:
     matrix:
-      linux_64_python3.8.____cpython:
-        CONFIG: linux_64_python3.8.____cpython
+      linux_64_python3.8.____cpythonvtk_build_variantegl:
+        CONFIG: linux_64_python3.8.____cpythonvtk_build_variantegl
         UPLOAD_PACKAGES: 'True'
-        DOCKER_IMAGE: quay.io/condaforge/linux-anvil-comp7
-      linux_64_python3.9.____cpython:
-        CONFIG: linux_64_python3.9.____cpython
+        DOCKER_IMAGE: quay.io/condaforge/linux-anvil-cos7-x86_64
+      linux_64_python3.8.____cpythonvtk_build_variantosmesa:
+        CONFIG: linux_64_python3.8.____cpythonvtk_build_variantosmesa
         UPLOAD_PACKAGES: 'True'
-        DOCKER_IMAGE: quay.io/condaforge/linux-anvil-comp7
+        DOCKER_IMAGE: quay.io/condaforge/linux-anvil-cos7-x86_64
+      linux_64_python3.8.____cpythonvtk_build_variantqt:
+        CONFIG: linux_64_python3.8.____cpythonvtk_build_variantqt
+        UPLOAD_PACKAGES: 'True'
+        DOCKER_IMAGE: quay.io/condaforge/linux-anvil-cos7-x86_64
+      linux_64_python3.9.____cpythonvtk_build_variantegl:
+        CONFIG: linux_64_python3.9.____cpythonvtk_build_variantegl
+        UPLOAD_PACKAGES: 'True'
+        DOCKER_IMAGE: quay.io/condaforge/linux-anvil-cos7-x86_64
+      linux_64_python3.9.____cpythonvtk_build_variantosmesa:
+        CONFIG: linux_64_python3.9.____cpythonvtk_build_variantosmesa
+        UPLOAD_PACKAGES: 'True'
+        DOCKER_IMAGE: quay.io/condaforge/linux-anvil-cos7-x86_64
+      linux_64_python3.9.____cpythonvtk_build_variantqt:
+        CONFIG: linux_64_python3.9.____cpythonvtk_build_variantqt
+        UPLOAD_PACKAGES: 'True'
+        DOCKER_IMAGE: quay.io/condaforge/linux-anvil-cos7-x86_64
   timeoutInMinutes: 360
 
   steps:

--- a/.ci_support/linux_64_python3.8.____cpythonvtk_build_variantegl.yaml
+++ b/.ci_support/linux_64_python3.8.____cpythonvtk_build_variantegl.yaml
@@ -1,11 +1,17 @@
 boost_cpp:
 - 1.74.0
+cdt_name:
+- cos6
 channel_sources:
 - conda-forge
 channel_targets:
 - conda-forge main
 cxx_compiler:
-- vs2017
+- gxx
+cxx_compiler_version:
+- '9'
+docker_image:
+- quay.io/condaforge/linux-anvil-cos7-x86_64
 freetype:
 - '2'
 hdf5:
@@ -31,11 +37,11 @@ python:
 qt:
 - '5.12'
 target_platform:
-- win-64
+- linux-64
 tbb_devel:
 - '2020'
 vtk_build_variant:
-- qt
+- egl
 xerces_c:
 - '3.2'
 zlib:

--- a/.ci_support/linux_64_python3.8.____cpythonvtk_build_variantosmesa.yaml
+++ b/.ci_support/linux_64_python3.8.____cpythonvtk_build_variantosmesa.yaml
@@ -1,11 +1,17 @@
 boost_cpp:
 - 1.74.0
+cdt_name:
+- cos6
 channel_sources:
 - conda-forge
 channel_targets:
 - conda-forge main
 cxx_compiler:
-- vs2017
+- gxx
+cxx_compiler_version:
+- '9'
+docker_image:
+- quay.io/condaforge/linux-anvil-cos7-x86_64
 freetype:
 - '2'
 hdf5:
@@ -31,11 +37,11 @@ python:
 qt:
 - '5.12'
 target_platform:
-- win-64
+- linux-64
 tbb_devel:
 - '2020'
 vtk_build_variant:
-- qt
+- osmesa
 xerces_c:
 - '3.2'
 zlib:

--- a/.ci_support/linux_64_python3.8.____cpythonvtk_build_variantqt.yaml
+++ b/.ci_support/linux_64_python3.8.____cpythonvtk_build_variantqt.yaml
@@ -1,11 +1,17 @@
 boost_cpp:
 - 1.74.0
+cdt_name:
+- cos6
 channel_sources:
 - conda-forge
 channel_targets:
 - conda-forge main
 cxx_compiler:
-- vs2017
+- gxx
+cxx_compiler_version:
+- '9'
+docker_image:
+- quay.io/condaforge/linux-anvil-cos7-x86_64
 freetype:
 - '2'
 hdf5:
@@ -31,7 +37,7 @@ python:
 qt:
 - '5.12'
 target_platform:
-- win-64
+- linux-64
 tbb_devel:
 - '2020'
 vtk_build_variant:

--- a/.ci_support/linux_64_python3.9.____cpythonvtk_build_variantegl.yaml
+++ b/.ci_support/linux_64_python3.9.____cpythonvtk_build_variantegl.yaml
@@ -1,11 +1,17 @@
 boost_cpp:
 - 1.74.0
+cdt_name:
+- cos6
 channel_sources:
 - conda-forge
 channel_targets:
 - conda-forge main
 cxx_compiler:
-- vs2017
+- gxx
+cxx_compiler_version:
+- '9'
+docker_image:
+- quay.io/condaforge/linux-anvil-cos7-x86_64
 freetype:
 - '2'
 hdf5:
@@ -27,15 +33,15 @@ pin_run_as_build:
   zlib:
     max_pin: x.x
 python:
-- 3.8.* *_cpython
+- 3.9.* *_cpython
 qt:
 - '5.12'
 target_platform:
-- win-64
+- linux-64
 tbb_devel:
 - '2020'
 vtk_build_variant:
-- qt
+- egl
 xerces_c:
 - '3.2'
 zlib:

--- a/.ci_support/linux_64_python3.9.____cpythonvtk_build_variantosmesa.yaml
+++ b/.ci_support/linux_64_python3.9.____cpythonvtk_build_variantosmesa.yaml
@@ -11,7 +11,7 @@ cxx_compiler:
 cxx_compiler_version:
 - '9'
 docker_image:
-- quay.io/condaforge/linux-anvil-comp7
+- quay.io/condaforge/linux-anvil-cos7-x86_64
 freetype:
 - '2'
 hdf5:
@@ -30,24 +30,19 @@ pin_run_as_build:
     max_pin: x.x
   qt:
     max_pin: x.x
-  vtk:
-    max_pin: x.x.x
   zlib:
     max_pin: x.x
 python:
-- 3.8.* *_cpython
+- 3.9.* *_cpython
 qt:
 - '5.12'
 target_platform:
 - linux-64
 tbb_devel:
 - '2020'
-vtk:
-- 9.0.1
+vtk_build_variant:
+- osmesa
 xerces_c:
 - '3.2'
-zip_keys:
-- - cdt_name
-  - docker_image
 zlib:
 - '1.2'

--- a/.ci_support/linux_64_python3.9.____cpythonvtk_build_variantqt.yaml
+++ b/.ci_support/linux_64_python3.9.____cpythonvtk_build_variantqt.yaml
@@ -11,7 +11,7 @@ cxx_compiler:
 cxx_compiler_version:
 - '9'
 docker_image:
-- quay.io/condaforge/linux-anvil-comp7
+- quay.io/condaforge/linux-anvil-cos7-x86_64
 freetype:
 - '2'
 hdf5:
@@ -30,8 +30,6 @@ pin_run_as_build:
     max_pin: x.x
   qt:
     max_pin: x.x
-  vtk:
-    max_pin: x.x.x
   zlib:
     max_pin: x.x
 python:
@@ -42,12 +40,9 @@ target_platform:
 - linux-64
 tbb_devel:
 - '2020'
-vtk:
-- 9.0.1
+vtk_build_variant:
+- qt
 xerces_c:
 - '3.2'
-zip_keys:
-- - cdt_name
-  - docker_image
 zlib:
 - '1.2'

--- a/.ci_support/osx_64_python3.8.____cpython.yaml
+++ b/.ci_support/osx_64_python3.8.____cpython.yaml
@@ -30,8 +30,6 @@ pin_run_as_build:
     max_pin: x.x
   qt:
     max_pin: x.x
-  vtk:
-    max_pin: x.x.x
   zlib:
     max_pin: x.x
 python:
@@ -42,8 +40,8 @@ target_platform:
 - osx-64
 tbb_devel:
 - '2020'
-vtk:
-- 9.0.1
+vtk_build_variant:
+- qt
 xerces_c:
 - '3.2'
 zlib:

--- a/.ci_support/osx_64_python3.9.____cpython.yaml
+++ b/.ci_support/osx_64_python3.9.____cpython.yaml
@@ -30,8 +30,6 @@ pin_run_as_build:
     max_pin: x.x
   qt:
     max_pin: x.x
-  vtk:
-    max_pin: x.x.x
   zlib:
     max_pin: x.x
 python:
@@ -42,8 +40,8 @@ target_platform:
 - osx-64
 tbb_devel:
 - '2020'
-vtk:
-- 9.0.1
+vtk_build_variant:
+- qt
 xerces_c:
 - '3.2'
 zlib:

--- a/.ci_support/win_64_python3.9.____cpython.yaml
+++ b/.ci_support/win_64_python3.9.____cpython.yaml
@@ -24,8 +24,6 @@ pin_run_as_build:
     max_pin: x.x
   qt:
     max_pin: x.x
-  vtk:
-    max_pin: x.x.x
   zlib:
     max_pin: x.x
 python:
@@ -36,8 +34,8 @@ target_platform:
 - win-64
 tbb_devel:
 - '2020'
-vtk:
-- 9.0.1
+vtk_build_variant:
+- qt
 xerces_c:
 - '3.2'
 zlib:

--- a/.scripts/build_steps.sh
+++ b/.scripts/build_steps.sh
@@ -5,6 +5,8 @@
 # changes to this script, consider a proposal to conda-smithy so that other feedstocks can also
 # benefit from the improvement.
 
+# -*- mode: jinja-shell -*-
+
 set -xeuo pipefail
 export FEEDSTOCK_ROOT="${FEEDSTOCK_ROOT:-/home/conda/feedstock_root}"
 source ${FEEDSTOCK_ROOT}/.scripts/logging_utils.sh
@@ -25,10 +27,10 @@ conda-build:
  root-dir: ${FEEDSTOCK_ROOT}/build_artifacts
 
 CONDARC
-GET_BOA=boa
-BUILD_CMD=mambabuild
 
-conda install --yes --quiet "conda-forge-ci-setup=3" conda-build pip ${GET_BOA:-} -c conda-forge
+
+mamba install --yes --quiet "conda-forge-ci-setup=3" conda-build pip boa -c conda-forge
+mamba update --yes --quiet "conda-forge-ci-setup=3" conda-build pip boa -c conda-forge
 
 # set up the condarc
 setup_conda_rc "${FEEDSTOCK_ROOT}" "${RECIPE_ROOT}" "${CONFIG_FILE}"
@@ -61,7 +63,7 @@ if [[ "${BUILD_WITH_CONDA_DEBUG:-0}" == 1 ]]; then
     # Drop into an interactive shell
     /bin/bash
 else
-    conda $BUILD_CMD "${RECIPE_ROOT}" -m "${CI_SUPPORT}/${CONFIG}.yaml" \
+    conda mambabuild "${RECIPE_ROOT}" -m "${CI_SUPPORT}/${CONFIG}.yaml" \
         --suppress-variables ${EXTRA_CB_OPTIONS:-} \
         --clobber-file "${CI_SUPPORT}/clobber_${CONFIG}.yaml"
     ( startgroup "Validating outputs" ) 2> /dev/null

--- a/.scripts/run_osx_build.sh
+++ b/.scripts/run_osx_build.sh
@@ -1,5 +1,7 @@
 #!/usr/bin/env bash
 
+# -*- mode: jinja-shell -*-
+
 source .scripts/logging_utils.sh
 
 set -xe
@@ -9,7 +11,7 @@ MINIFORGE_HOME=${MINIFORGE_HOME:-${HOME}/miniforge3}
 ( startgroup "Installing a fresh version of Miniforge" ) 2> /dev/null
 
 MINIFORGE_URL="https://github.com/conda-forge/miniforge/releases/latest/download"
-MINIFORGE_FILE="Miniforge3-MacOSX-$(uname -m).sh"
+MINIFORGE_FILE="Mambaforge-MacOSX-$(uname -m).sh"
 curl -L -O "${MINIFORGE_URL}/${MINIFORGE_FILE}"
 rm -rf ${MINIFORGE_HOME}
 bash $MINIFORGE_FILE -b -p ${MINIFORGE_HOME}
@@ -18,14 +20,12 @@ bash $MINIFORGE_FILE -b -p ${MINIFORGE_HOME}
 
 ( startgroup "Configuring conda" ) 2> /dev/null
 
-GET_BOA=boa
-BUILD_CMD=mambabuild
-
 source ${MINIFORGE_HOME}/etc/profile.d/conda.sh
 conda activate base
 
 echo -e "\n\nInstalling conda-forge-ci-setup=3 and conda-build."
-conda install -n base --quiet --yes "conda-forge-ci-setup=3" conda-build pip ${GET_BOA:-}
+mamba install -n base --quiet --yes "conda-forge-ci-setup=3" conda-build pip boa
+mamba update -n base --quiet --yes "conda-forge-ci-setup=3" conda-build pip boa
 
 
 
@@ -55,7 +55,7 @@ source run_conda_forge_build_setup
 echo -e "\n\nMaking the build clobber file"
 make_build_number ./ ./recipe ./.ci_support/${CONFIG}.yaml
 
-conda $BUILD_CMD ./recipe -m ./.ci_support/${CONFIG}.yaml --suppress-variables --clobber-file ./.ci_support/clobber_${CONFIG}.yaml ${EXTRA_CB_OPTIONS:-}
+conda mambabuild ./recipe -m ./.ci_support/${CONFIG}.yaml --suppress-variables --clobber-file ./.ci_support/clobber_${CONFIG}.yaml ${EXTRA_CB_OPTIONS:-}
 ( startgroup "Validating outputs" ) 2> /dev/null
 
 validate_recipe_outputs "${FEEDSTOCK_NAME}"

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ About freecad
 
 Home: https://www.freecadweb.org/
 
-Package license: LGPL2.1
+Package license: LGPL-2.1-or-later
 
 Feedstock license: [BSD-3-Clause](https://github.com/conda-forge/freecad-feedstock/blob/master/LICENSE.txt)
 
@@ -44,17 +44,45 @@ Current build status
         <table>
           <thead><tr><th>Variant</th><th>Status</th></tr></thead>
           <tbody><tr>
-              <td>linux_64_python3.8.____cpython</td>
+              <td>linux_64_python3.8.____cpythonvtk_build_variantegl</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=5916&branchName=master">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/freecad-feedstock?branchName=master&jobName=linux&configuration=linux_64_python3.8.____cpython" alt="variant">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/freecad-feedstock?branchName=master&jobName=linux&configuration=linux_64_python3.8.____cpythonvtk_build_variantegl" alt="variant">
                 </a>
               </td>
             </tr><tr>
-              <td>linux_64_python3.9.____cpython</td>
+              <td>linux_64_python3.8.____cpythonvtk_build_variantosmesa</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=5916&branchName=master">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/freecad-feedstock?branchName=master&jobName=linux&configuration=linux_64_python3.9.____cpython" alt="variant">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/freecad-feedstock?branchName=master&jobName=linux&configuration=linux_64_python3.8.____cpythonvtk_build_variantosmesa" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
+              <td>linux_64_python3.8.____cpythonvtk_build_variantqt</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=5916&branchName=master">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/freecad-feedstock?branchName=master&jobName=linux&configuration=linux_64_python3.8.____cpythonvtk_build_variantqt" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
+              <td>linux_64_python3.9.____cpythonvtk_build_variantegl</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=5916&branchName=master">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/freecad-feedstock?branchName=master&jobName=linux&configuration=linux_64_python3.9.____cpythonvtk_build_variantegl" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
+              <td>linux_64_python3.9.____cpythonvtk_build_variantosmesa</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=5916&branchName=master">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/freecad-feedstock?branchName=master&jobName=linux&configuration=linux_64_python3.9.____cpythonvtk_build_variantosmesa" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
+              <td>linux_64_python3.9.____cpythonvtk_build_variantqt</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=5916&branchName=master">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/freecad-feedstock?branchName=master&jobName=linux&configuration=linux_64_python3.9.____cpythonvtk_build_variantqt" alt="variant">
                 </a>
               </td>
             </tr><tr>

--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -1,2 +1,6 @@
+vtk_build_variant:
+  - "qt"
+  - "osmesa"  # [linux64]
+  - "egl"  # [linux64]
 MACOSX_DEPLOYMENT_TARGET:  # [osx]
 - '10.12'                  # [osx]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,6 +1,6 @@
 {% set name = "freecad" %}
 {% set version = "0.19.3" %}
-{% set build_number = 0 %}
+{% set build_number = 1 %}
 {% set build_number = build_number + 1000 %}  # [FEATURE_DEBUG]
 {% set build_number = build_number + 2000 %}   # [vtk_build_variant == "osmesa"]
 {% set build_number = build_number + 3000 %}   # [vtk_build_variant == "qt"]
@@ -32,6 +32,7 @@ requirements:
         - {{ cdt('xorg-x11-server-xvfb') }}  # [linux and build_variant != "osmesa"]
         - {{ cdt('libxau') }}                # [linux and build_variant != "osmesa"]
         - {{ cdt('libxi-devel') }}           # [linux]
+        - sysroot_linux-64 2.17              # [build_variant == "osmesa"]
         - cmake
         - ninja
         - sed  # [unix]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -2,6 +2,8 @@
 {% set version = "0.19.3" %}
 {% set build_number = 0 %}
 {% set build_number = build_number + 1000 %}  # [FEATURE_DEBUG]
+{% set build_number = build_number + 2000 %}   # [vtk_build_variant == "osmesa"]
+{% set build_number = build_number + 3000 %}   # [vtk_build_variant == "qt"]
 
 package:
     name: {{ name }}
@@ -18,17 +20,17 @@ build:
 requirements:
     build:
         - {{ compiler("cxx") }}
-        - {{ cdt('mesa-libgl-devel') }}      # [linux]
-        - {{ cdt('mesa-dri-drivers') }}      # [linux]
-        - {{ cdt('mesa-libegl-devel') }}     # [linux]
-        - {{ cdt('libselinux') }}            # [linux]
-        - {{ cdt('libxdamage') }}            # [linux]
-        - {{ cdt('libxfixes') }}             # [linux]
-        - {{ cdt('libxxf86vm') }}            # [linux]
-        - {{ cdt('libxcb') }}                # [linux]
-        - {{ cdt('libxext') }}               # [linux]
-        - {{ cdt('xorg-x11-server-xvfb') }}  # [linux]
-        - {{ cdt('libxau') }}                # [linux]
+        - {{ cdt('mesa-libgl-devel') }}      # [linux and build_variant != "osmesa"]
+        - {{ cdt('mesa-dri-drivers') }}      # [linux and build_variant != "osmesa"]
+        - {{ cdt('mesa-libegl-devel') }}     # [linux and build_variant != "osmesa"]
+        - {{ cdt('libselinux') }}            # [linux and build_variant != "osmesa"]
+        - {{ cdt('libxdamage') }}            # [linux and build_variant != "osmesa"]
+        - {{ cdt('libxfixes') }}             # [linux and build_variant != "osmesa"]
+        - {{ cdt('libxxf86vm') }}            # [linux and build_variant != "osmesa"]
+        - {{ cdt('libxcb') }}                # [linux and build_variant != "osmesa"]
+        - {{ cdt('libxext') }}               # [linux and build_variant != "osmesa"]
+        - {{ cdt('xorg-x11-server-xvfb') }}  # [linux and build_variant != "osmesa"]
+        - {{ cdt('libxau') }}                # [linux and build_variant != "osmesa"]
         - {{ cdt('libxi-devel') }}           # [linux]
         - cmake
         - ninja
@@ -40,7 +42,9 @@ requirements:
         - occt
         - xerces-c
         - zlib
-        - vtk
+        - vtk * qt*  # [vtk_build_variant == "qt"]
+        - vtk * osmesa*  # [vtk_build_variant == "osmesa"]
+        - vtk * egl*  # [vtk_build_variant == "egl"]
         - swig
         - eigen
         - pybind11 =2.7
@@ -59,7 +63,9 @@ requirements:
         - tbb-devel
     run:
         - pyside2
-        - vtk
+        - vtk * qt*  # [vtk_build_variant == "qt"]
+        - vtk * osmesa*  # [vtk_build_variant == "osmesa"]
+        - vtk * egl*  # [vtk_build_variant == "egl"]
         - occt
         - qt
         - xerces-c

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -88,8 +88,8 @@ requirements:
         - __osx >={{ MACOSX_DEPLOYMENT_TARGET|default("10.9") }}  # [osx]
 
 test:
-   commands:
-       - freecadcmd -t 0  # [unix]
+    commands:
+        - freecadcmd -t 0  # [unix]
 
 about:
     home: https://www.freecadweb.org/


### PR DESCRIPTION
<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [x] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

This allows people to use the different VTK variants. The EGL and OSMesa variants enable usage on headless (display-less) machines such as on supercomputers.

<!--
Please add any other relevant info below:
-->
